### PR TITLE
[feat] 사용자별 시나리오 진행 상태 조회

### DIFF
--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
@@ -13,6 +13,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 사용자의 시나리오 진행 현황(완료/진행률)을 조회하는 컨트롤러
+ *
+ * BaseURL : /users/me/scenarios
+ *  - /completed : 완료한 시나리오 목록 조회
+ *  - /progress : 시나리오의 진행률 조회
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/users/me/scenarios")

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
@@ -1,0 +1,46 @@
+package dev.woori.wooriLearn.domain.scenario.controller;
+
+import dev.woori.wooriLearn.config.response.ApiResponse;
+import dev.woori.wooriLearn.config.response.BaseResponse;
+import dev.woori.wooriLearn.config.response.SuccessCode;
+import dev.woori.wooriLearn.domain.scenario.service.ScenarioStatusService;
+import dev.woori.wooriLearn.domain.user.entity.Users;
+import dev.woori.wooriLearn.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/users/me/scenarios")
+public class ScenarioStatusController {
+
+    private final ScenarioStatusService scenarioStatusService;
+    private final UserService userService;
+
+    @GetMapping("/completed")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<?>> getMyCompletedScenarios(
+            @AuthenticationPrincipal String username
+    ) {
+        Users me = getMe(username);
+        return ApiResponse.success(SuccessCode.OK, scenarioStatusService.getCompletedScenarios(me));
+    }
+
+    @GetMapping("/progress")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BaseResponse<?>> getMyScenarioProgress(
+            @AuthenticationPrincipal String username
+    ) {
+        Users me = getMe(username);
+        return ApiResponse.success(SuccessCode.OK, scenarioStatusService.getScenarioProgress(me));
+    }
+
+    private Users getMe(String username) {
+        return userService.getByUserIdOrThrow(username);
+    }
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
@@ -4,7 +4,6 @@ import dev.woori.wooriLearn.config.response.ApiResponse;
 import dev.woori.wooriLearn.config.response.BaseResponse;
 import dev.woori.wooriLearn.config.response.SuccessCode;
 import dev.woori.wooriLearn.domain.scenario.service.ScenarioStatusService;
-import dev.woori.wooriLearn.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -26,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScenarioStatusController {
 
     private final ScenarioStatusService scenarioStatusService;
-    private final UserService userService;
 
     @GetMapping("/completed")
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
@@ -27,8 +27,7 @@ public class ScenarioStatusController {
     public ResponseEntity<BaseResponse<?>> getMyCompletedScenarios(
             @AuthenticationPrincipal String username
     ) {
-        Users me = getMe(username);
-        return ApiResponse.success(SuccessCode.OK, scenarioStatusService.getCompletedScenarios(me));
+        return ApiResponse.success(SuccessCode.OK, scenarioStatusService.getCompletedScenarios(username));
     }
 
     @GetMapping("/progress")
@@ -36,11 +35,6 @@ public class ScenarioStatusController {
     public ResponseEntity<BaseResponse<?>> getMyScenarioProgress(
             @AuthenticationPrincipal String username
     ) {
-        Users me = getMe(username);
-        return ApiResponse.success(SuccessCode.OK, scenarioStatusService.getScenarioProgress(me));
-    }
-
-    private Users getMe(String username) {
-        return userService.getByUserIdOrThrow(username);
+        return ApiResponse.success(SuccessCode.OK, scenarioStatusService.getScenarioProgress(username));
     }
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/controller/ScenarioStatusController.java
@@ -4,7 +4,6 @@ import dev.woori.wooriLearn.config.response.ApiResponse;
 import dev.woori.wooriLearn.config.response.BaseResponse;
 import dev.woori.wooriLearn.config.response.SuccessCode;
 import dev.woori.wooriLearn.domain.scenario.service.ScenarioStatusService;
-import dev.woori.wooriLearn.domain.user.entity.Users;
 import dev.woori.wooriLearn.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioCompletedResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioCompletedResDto.java
@@ -1,0 +1,19 @@
+package dev.woori.wooriLearn.domain.scenario.dto;
+
+import dev.woori.wooriLearn.domain.scenario.entity.ScenarioCompleted;
+
+import java.time.LocalDateTime;
+
+public record ScenarioCompletedResDto(
+        Long scenarioId,
+        String title,
+        LocalDateTime completedAt
+) {
+    public static ScenarioCompletedResDto from(ScenarioCompleted entity) {
+        return new ScenarioCompletedResDto(
+                entity.getScenario().getId(),
+                entity.getScenario().getTitle(),
+                entity.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioCompletedResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioCompletedResDto.java
@@ -4,11 +4,22 @@ import dev.woori.wooriLearn.domain.scenario.entity.ScenarioCompleted;
 
 import java.time.LocalDateTime;
 
+/**
+ * 사용자가 완료한 시나리오 정보를 내려주는 응답 DTO
+ * @param scenarioId    완료한 시나리오 ID
+ * @param title         완료한 시나리오 제목
+ * @param completedAt   완료한 시각
+ */
 public record ScenarioCompletedResDto(
         Long scenarioId,
         String title,
         LocalDateTime completedAt
 ) {
+    /**
+     * ScenarioCompleted 엔티티에서 응답 DTO로 변환하는 정적 팩토리 메서드
+     * @param entity    완료된 시나리오 엔티티
+     * @return ScenarioCompletedResDto 응답 객체
+     */
     public static ScenarioCompletedResDto from(ScenarioCompleted entity) {
         return new ScenarioCompletedResDto(
                 entity.getScenario().getId(),

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioProgressResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioProgressResDto.java
@@ -2,11 +2,22 @@ package dev.woori.wooriLearn.domain.scenario.dto;
 
 import dev.woori.wooriLearn.domain.scenario.entity.ScenarioProgress;
 
+/**
+ * 사용자가 진행 중인 시나리오의 진행률 정보를 내려주는 응답 DTO
+ * @param scenarioId    진행 중인 시나리오 ID
+ * @param title         진행 중인 시나리오 제목
+ * @param progressRate  시나리오 진행률 (0.0 ~ 100.0)
+ */
 public record ScenarioProgressResDto(
         Long scenarioId,
         String title,
         Double progressRate
 ) {
+    /**
+     * ScenarioProgress 엔티티에서 응답 DTO로 변환하는 정적 팩토리 메서드
+     * @param entity    시나리오 진행 상태 엔티티
+     * @return ScenarioProgressResDto 응답 객체
+     */
     public static ScenarioProgressResDto from(ScenarioProgress entity) {
         return new ScenarioProgressResDto(
                 entity.getScenario().getId(),

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioProgressResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/dto/ScenarioProgressResDto.java
@@ -1,0 +1,17 @@
+package dev.woori.wooriLearn.domain.scenario.dto;
+
+import dev.woori.wooriLearn.domain.scenario.entity.ScenarioProgress;
+
+public record ScenarioProgressResDto(
+        Long scenarioId,
+        String title,
+        Double progressRate
+) {
+    public static ScenarioProgressResDto from(ScenarioProgress entity) {
+        return new ScenarioProgressResDto(
+                entity.getScenario().getId(),
+                entity.getScenario().getTitle(),
+                entity.getProgressRate()
+        );
+    }
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/entity/ScenarioCompleted.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/entity/ScenarioCompleted.java
@@ -2,10 +2,7 @@ package dev.woori.wooriLearn.domain.scenario.entity;
 
 import dev.woori.wooriLearn.domain.user.entity.Users;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -13,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "scenario_completed")
+@Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
@@ -3,15 +3,14 @@ package dev.woori.wooriLearn.domain.scenario.repository;
 import dev.woori.wooriLearn.domain.scenario.entity.Scenario;
 import dev.woori.wooriLearn.domain.scenario.entity.ScenarioCompleted;
 import dev.woori.wooriLearn.domain.user.entity.Users;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ScenarioCompletedRepository extends JpaRepository<ScenarioCompleted, Long> {
     boolean existsByUserAndScenario(Users user, Scenario scenario);
 
-    @Query("SELECT sc FROM ScenarioCompleted sc JOIN FETCH sc.scenario WHERE sc.user = :user")
-    List<ScenarioCompleted> findByUser(@Param("user") Users user);
+    @EntityGraph(attributePaths = "scenario")
+    List<ScenarioCompleted> findByUser(Users user);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
@@ -4,11 +4,14 @@ import dev.woori.wooriLearn.domain.scenario.entity.Scenario;
 import dev.woori.wooriLearn.domain.scenario.entity.ScenarioCompleted;
 import dev.woori.wooriLearn.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ScenarioCompletedRepository extends JpaRepository<ScenarioCompleted, Long> {
     boolean existsByUserAndScenario(Users user, Scenario scenario);
 
-    List<ScenarioCompleted> findByUser(Users user);
+    @Query("SELECT sc FROM ScenarioCompleted sc JOIN FETCH sc.scenario WHERE sc.user = :user")
+    List<ScenarioCompleted> findByUser(@Param("user") Users user);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
@@ -5,8 +5,10 @@ import dev.woori.wooriLearn.domain.scenario.entity.ScenarioCompleted;
 import dev.woori.wooriLearn.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface ScenarioCompletedRepository extends JpaRepository<ScenarioCompleted, Long> {
     boolean existsByUserAndScenario(Users user, Scenario scenario);
+
+    List<ScenarioCompleted> findByUser(Users user);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioProgressRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioProgressRepository.java
@@ -4,6 +4,8 @@ import dev.woori.wooriLearn.domain.scenario.entity.Scenario;
 import dev.woori.wooriLearn.domain.scenario.entity.ScenarioProgress;
 import dev.woori.wooriLearn.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,5 +13,6 @@ import java.util.Optional;
 public interface ScenarioProgressRepository extends JpaRepository<ScenarioProgress, Long> {
     Optional<ScenarioProgress> findByUserAndScenario(Users user, Scenario scenario);
 
-    List<ScenarioProgress> findByUser(Users user);
+    @Query("SELECT sp FROM ScenarioProgress sp JOIN FETCH sp.scenario WHERE sp.user = :user")
+    List<ScenarioProgress> findByUser(@Param("user") Users user);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioProgressRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioProgressRepository.java
@@ -3,9 +3,8 @@ package dev.woori.wooriLearn.domain.scenario.repository;
 import dev.woori.wooriLearn.domain.scenario.entity.Scenario;
 import dev.woori.wooriLearn.domain.scenario.entity.ScenarioProgress;
 import dev.woori.wooriLearn.domain.user.entity.Users;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +12,6 @@ import java.util.Optional;
 public interface ScenarioProgressRepository extends JpaRepository<ScenarioProgress, Long> {
     Optional<ScenarioProgress> findByUserAndScenario(Users user, Scenario scenario);
 
-    @Query("SELECT sp FROM ScenarioProgress sp JOIN FETCH sp.scenario WHERE sp.user = :user")
-    List<ScenarioProgress> findByUser(@Param("user") Users user);
+    @EntityGraph(attributePaths = "scenario")
+    List<ScenarioProgress> findByUser(Users user);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioProgressRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioProgressRepository.java
@@ -5,8 +5,11 @@ import dev.woori.wooriLearn.domain.scenario.entity.ScenarioProgress;
 import dev.woori.wooriLearn.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScenarioProgressRepository extends JpaRepository<ScenarioProgress, Long> {
     Optional<ScenarioProgress> findByUserAndScenario(Users user, Scenario scenario);
+
+    List<ScenarioProgress> findByUser(Users user);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/service/ScenarioStatusService.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/service/ScenarioStatusService.java
@@ -12,6 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+/**
+ * 사용자의 시나리오 진행 현황(완료/진행률)을 조회하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,6 +24,17 @@ public class ScenarioStatusService {
     private final ScenarioProgressRepository scenarioProgressRepository;
     private final UserService userService;
 
+    /**
+     * 사용자가 완료한 시나리오 목록 조회
+     *
+     * 흐름
+     * 1) username으로 Users 엔티티 조회
+     * 2) 해당 사용자 기준으로 ScenarioCompleted 목록 조회
+     * 3) 엔티티 리스트를 ScenarioCompletedResDto 리스트로 변환 후 반환
+     *
+     * @param username 인증 정보에서 가져온 사용자 식별자
+     * @return 완료한 시나리오 목록 응답 DTO 리스트
+     */
     public List<ScenarioCompletedResDto> getCompletedScenarios(String username) {
         Users user = userService.getByUserIdOrThrow(username);
         return scenarioCompletedRepository.findByUser(user).stream()
@@ -28,6 +42,17 @@ public class ScenarioStatusService {
                 .toList();
     }
 
+    /**
+     * 사용자가 진행 중인 시나리오 진행률 조회
+     *
+     * 흐름
+     * 1) username으로 Users 엔티티 조회
+     * 2) 해당 사용자 기준으로 ScenarioProgress 목록 조회
+     * 3) 엔티티 리스트를 ScenarioProgressResDto 리스트로 변환 후 반환
+     *
+     * @param username 인증 정보에서 가져온 사용자 식별자
+     * @return 각 시나리오의 진행률 목록 응답 DTO 리스트
+     */
     public List<ScenarioProgressResDto> getScenarioProgress(String username) {
         Users user = userService.getByUserIdOrThrow(username);
         return scenarioProgressRepository.findByUser(user).stream()

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/service/ScenarioStatusService.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/service/ScenarioStatusService.java
@@ -1,0 +1,33 @@
+package dev.woori.wooriLearn.domain.scenario.service;
+
+import dev.woori.wooriLearn.domain.scenario.dto.ScenarioCompletedResDto;
+import dev.woori.wooriLearn.domain.scenario.dto.ScenarioProgressResDto;
+import dev.woori.wooriLearn.domain.scenario.repository.ScenarioCompletedRepository;
+import dev.woori.wooriLearn.domain.scenario.repository.ScenarioProgressRepository;
+import dev.woori.wooriLearn.domain.user.entity.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScenarioStatusService {
+
+    private final ScenarioCompletedRepository scenarioCompletedRepository;
+    private final ScenarioProgressRepository scenarioProgressRepository;
+
+    public List<ScenarioCompletedResDto> getCompletedScenarios(Users user) {
+        return scenarioCompletedRepository.findByUser(user).stream()
+                .map(ScenarioCompletedResDto::from)
+                .toList();
+    }
+
+    public List<ScenarioProgressResDto> getScenarioProgress(Users user) {
+        return scenarioProgressRepository.findByUser(user).stream()
+                .map(ScenarioProgressResDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/service/ScenarioStatusService.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/service/ScenarioStatusService.java
@@ -5,6 +5,7 @@ import dev.woori.wooriLearn.domain.scenario.dto.ScenarioProgressResDto;
 import dev.woori.wooriLearn.domain.scenario.repository.ScenarioCompletedRepository;
 import dev.woori.wooriLearn.domain.scenario.repository.ScenarioProgressRepository;
 import dev.woori.wooriLearn.domain.user.entity.Users;
+import dev.woori.wooriLearn.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,14 +19,17 @@ public class ScenarioStatusService {
 
     private final ScenarioCompletedRepository scenarioCompletedRepository;
     private final ScenarioProgressRepository scenarioProgressRepository;
+    private final UserService userService;
 
-    public List<ScenarioCompletedResDto> getCompletedScenarios(Users user) {
+    public List<ScenarioCompletedResDto> getCompletedScenarios(String username) {
+        Users user = userService.getByUserIdOrThrow(username);
         return scenarioCompletedRepository.findByUser(user).stream()
                 .map(ScenarioCompletedResDto::from)
                 .toList();
     }
 
-    public List<ScenarioProgressResDto> getScenarioProgress(Users user) {
+    public List<ScenarioProgressResDto> getScenarioProgress(String username) {
+        Users user = userService.getByUserIdOrThrow(username);
         return scenarioProgressRepository.findByUser(user).stream()
                 .map(ScenarioProgressResDto::from)
                 .toList();


### PR DESCRIPTION
## ✅ 연관된 이슈
#55

## 📝 작업 내용
> 사용자별 각 시나리오 완료 여부 조회 및 사용자별 각 시나리오 진행률 조회

## 🖼️ 스크린샷 (선택)
사용자별 각 시나리오 완료 여부 조회
`GET {{baseURL}}/users/me/scenarios/completed` + bearer token
<img width="716" height="162" alt="스크린샷 2025-11-17 164127" src="https://github.com/user-attachments/assets/ae40bfe1-ba56-4c88-a5ab-31c3b0c41f58" />
<img width="508" height="360" alt="스크린샷 2025-11-17 164118" src="https://github.com/user-attachments/assets/18c8c1b5-748e-426f-9158-0ba07670c380" />

사용자별 각 시나리오 진행률 조회
`GET {{baseURL}}/users/me/scenarios/progress` + bearer token
<img width="1372" height="156" alt="스크린샷 2025-11-17 164454" src="https://github.com/user-attachments/assets/6878d96e-4250-44b1-bdb2-a3fd8226a169" />
<img width="320" height="364" alt="스크린샷 2025-11-17 164442" src="https://github.com/user-attachments/assets/5b9816ac-41f7-4b11-99bd-d6631ff738e9" />