### PR TITLE
[feat] 로그인 시 role 정보도 함께 응답하도록 변경

### DIFF
--- a/src/main/java/dev/woori/wooriLearn/domain/auth/controller/AuthController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/auth/controller/AuthController.java
@@ -5,7 +5,6 @@ import dev.woori.wooriLearn.config.response.ApiResponse;
 import dev.woori.wooriLearn.config.response.BaseResponse;
 import dev.woori.wooriLearn.config.response.SuccessCode;
 import dev.woori.wooriLearn.domain.auth.dto.LoginResDto;
-import dev.woori.wooriLearn.domain.auth.dto.RefreshResDto;
 import dev.woori.wooriLearn.domain.auth.service.AuthService;
 import dev.woori.wooriLearn.domain.auth.dto.LoginReqDto;
 import dev.woori.wooriLearn.domain.auth.dto.ChangePasswdReqDto;
@@ -43,8 +42,8 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<BaseResponse<?>> refresh(@CookieValue("refreshToken") String refreshToken) {
         TokenWithCookie tokenWithCookie = authService.refresh(refreshToken);
-        RefreshResDto refreshResDto = new RefreshResDto(tokenWithCookie.accessToken());
-        return ApiResponse.successWithCookie(SuccessCode.OK, refreshResDto, tokenWithCookie.cookie());
+        LoginResDto loginResDto = new LoginResDto(tokenWithCookie.accessToken(), tokenWithCookie.role());
+        return ApiResponse.successWithCookie(SuccessCode.OK, loginResDto, tokenWithCookie.cookie());
     }
 
     @PostMapping("/logout")

--- a/src/main/java/dev/woori/wooriLearn/domain/auth/controller/AuthController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import dev.woori.wooriLearn.config.response.ApiResponse;
 import dev.woori.wooriLearn.config.response.BaseResponse;
 import dev.woori.wooriLearn.config.response.SuccessCode;
 import dev.woori.wooriLearn.domain.auth.dto.LoginResDto;
+import dev.woori.wooriLearn.domain.auth.dto.RefreshResDto;
 import dev.woori.wooriLearn.domain.auth.service.AuthService;
 import dev.woori.wooriLearn.domain.auth.dto.LoginReqDto;
 import dev.woori.wooriLearn.domain.auth.dto.ChangePasswdReqDto;
@@ -29,7 +30,7 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<?>> login(@Valid @RequestBody LoginReqDto loginReqDto) {
         TokenWithCookie tokenWithCookie = authService.login(loginReqDto);
-        LoginResDto loginResDto = new LoginResDto(tokenWithCookie.accessToken());
+        LoginResDto loginResDto = new LoginResDto(tokenWithCookie.accessToken(), tokenWithCookie.role());
         return ApiResponse.successWithCookie(SuccessCode.OK, loginResDto, tokenWithCookie.cookie());
     }
 
@@ -42,8 +43,8 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<BaseResponse<?>> refresh(@CookieValue("refreshToken") String refreshToken) {
         TokenWithCookie tokenWithCookie = authService.refresh(refreshToken);
-        LoginResDto loginResDto = new LoginResDto(tokenWithCookie.accessToken());
-        return ApiResponse.successWithCookie(SuccessCode.OK, loginResDto, tokenWithCookie.cookie());
+        RefreshResDto refreshResDto = new RefreshResDto(tokenWithCookie.accessToken());
+        return ApiResponse.successWithCookie(SuccessCode.OK, refreshResDto, tokenWithCookie.cookie());
     }
 
     @PostMapping("/logout")

--- a/src/main/java/dev/woori/wooriLearn/domain/auth/dto/LoginResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/auth/dto/LoginResDto.java
@@ -1,6 +1,7 @@
 package dev.woori.wooriLearn.domain.auth.dto;
 
 public record LoginResDto(
-        String accessToken
+        String accessToken,
+        String role
 ) {
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/auth/dto/RefreshResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/auth/dto/RefreshResDto.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriLearn.domain.auth.dto;
+
+public record RefreshResDto(
+        String accessToken
+) {
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/auth/dto/RefreshResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/auth/dto/RefreshResDto.java
@@ -1,6 +1,0 @@
-package dev.woori.wooriLearn.domain.auth.dto;
-
-public record RefreshResDto(
-        String accessToken
-) {
-}

--- a/src/main/java/dev/woori/wooriLearn/domain/auth/service/AuthService.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/auth/service/AuthService.java
@@ -131,6 +131,6 @@ public class AuthService {
         refreshTokenRepository.save(token);
 
         long maxAgeSeconds = refreshTokenExpiration.getEpochSecond() - Instant.now().getEpochSecond();
-        return new TokenWithCookie(accessToken, CookieUtil.createRefreshTokenCookie(refreshToken, maxAgeSeconds));
+        return new TokenWithCookie(accessToken, role.name(), CookieUtil.createRefreshTokenCookie(refreshToken, maxAgeSeconds));
     }
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/auth/service/TokenWithCookie.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/auth/service/TokenWithCookie.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseCookie;
 
 public record TokenWithCookie(
         String accessToken,
+        String role,
         ResponseCookie cookie
 ) {
 }


### PR DESCRIPTION
## ✅ 연관된 이슈
#73 

## 📝 작업 내용
프론트 페이지에서 분기 처리를 위해
로그인 시 role 정보도 함께 응답하도록 변경했습니다.

## 🖼️ 스크린샷 (선택)
<img width="1051" height="703" alt="image" src="https://github.com/user-attachments/assets/6c5f93d3-05bb-4086-9dc8-5d8fc6445308" />

ROLE_USER의 형식으로 응답이 옵니다.
(관리자의 경우 ROLE_ADMIN)