### PR TITLE
[feat] 회원목록 조회 시 전체 시나리오 진행률도 응답하도록 수정

### DIFF
--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedCount.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedCount.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriLearn.domain.scenario.repository;
+
+public interface ScenarioCompletedCount {
+    Long getUserId();
+    Long getCompletedCount();
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
@@ -5,6 +5,8 @@ import dev.woori.wooriLearn.domain.scenario.entity.ScenarioCompleted;
 import dev.woori.wooriLearn.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,5 +16,11 @@ public interface ScenarioCompletedRepository extends JpaRepository<ScenarioCompl
     @EntityGraph(attributePaths = "scenario")
     List<ScenarioCompleted> findByUser(Users user);
 
-    long countByUserId(Long userId);
+    @Query("""
+        SELECT sc.user.id AS userId, COUNT(sc) AS completedCount
+        FROM ScenarioCompleted sc
+        WHERE sc.user.id IN :userIds
+        GROUP BY sc.user.id
+    """)
+    List<ScenarioCompletedCount> countCompletedByUserIds(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/scenario/repository/ScenarioCompletedRepository.java
@@ -13,4 +13,6 @@ public interface ScenarioCompletedRepository extends JpaRepository<ScenarioCompl
 
     @EntityGraph(attributePaths = "scenario")
     List<ScenarioCompleted> findByUser(Users user);
+
+    long countByUserId(Long userId);
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/user/dto/AdminUserListResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/user/dto/AdminUserListResDto.java
@@ -12,6 +12,7 @@ public record AdminUserListResDto(
         String nickname,
         int points,
         Role role,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        double progressRate
 ) {
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/user/service/AdminUserService.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/user/service/AdminUserService.java
@@ -1,6 +1,8 @@
 package dev.woori.wooriLearn.domain.user.service;
 
 import dev.woori.wooriLearn.config.response.PageResponse;
+import dev.woori.wooriLearn.domain.scenario.repository.ScenarioCompletedRepository;
+import dev.woori.wooriLearn.domain.scenario.repository.ScenarioRepository;
 import dev.woori.wooriLearn.domain.user.dto.AdminUserListResDto;
 import dev.woori.wooriLearn.domain.user.entity.Users;
 import dev.woori.wooriLearn.domain.user.repository.UserRepository;
@@ -22,6 +24,8 @@ import java.util.List;
 public class AdminUserService {
 
     private final UserRepository userRepository;
+    private final ScenarioRepository scenarioRepository;
+    private final ScenarioCompletedRepository scenarioCompletedRepository;
 
     @Transactional(readOnly = true)
     public PageResponse<AdminUserListResDto> getAdminUserList(int page, int size) {
@@ -36,9 +40,21 @@ public class AdminUserService {
                         .points(user.getPoints())
                         .role(user.getAuthUser().getRole())
                         .createdAt(user.getCreatedAt())
+                        .progressRate(getOverallProgress(user.getId()))
                         .build())
                 .toList();
 
         return PageResponse.of(usersPage, content);
+    }
+
+    private double getOverallProgress(Long userId){
+        long totalScenarioCount = scenarioRepository.count();
+        long completedScenarioCount = scenarioCompletedRepository.countByUserId(userId);
+
+        if (totalScenarioCount == 0) {
+            return 0; // 시나리오 없으면 0%
+        }
+
+        return (completedScenarioCount * 100.0) / totalScenarioCount;
     }
 }


### PR DESCRIPTION
## ✅ 연관된 이슈
#75 

## 📝 작업 내용
- 회원목록 조회 시 전체 시나리오 진행률도 응답하도록 수정
- 시나리오 진행률 계산하는 함수 추가

## 🖼️ 스크린샷 (선택)
<img width="1032" height="870" alt="image" src="https://github.com/user-attachments/assets/63128af8-2a3b-4ebe-bfdb-9fd0feec05f0" />
