### PR TITLE
[feat] 계좌개설 url 제공 api 구현

### DIFF
--- a/src/main/java/dev/woori/wooriLearn/domain/account/controller/AccountController.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/controller/AccountController.java
@@ -1,7 +1,27 @@
 package dev.woori.wooriLearn.domain.account.controller;
 
+import dev.woori.wooriLearn.config.response.ApiResponse;
+import dev.woori.wooriLearn.config.response.BaseResponse;
+import dev.woori.wooriLearn.config.response.SuccessCode;
+import dev.woori.wooriLearn.domain.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/account")
 public class AccountController {
 
+    private final AccountService accountService;
 
+    @PostMapping("/url")
+    public ResponseEntity<BaseResponse<?>> getBankUrl(Principal principal) {
+        String userId = principal.getName();
+        return ApiResponse.success(SuccessCode.OK, accountService.getAccountUrl(userId));
+    }
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/account/dto/AccountUrlResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/dto/AccountUrlResDto.java
@@ -1,0 +1,10 @@
+package dev.woori.wooriLearn.domain.account.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AccountUrlResDto(
+        String accessToken,
+        String url
+) {
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/account/dto/BankTokenReqDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/dto/BankTokenReqDto.java
@@ -1,0 +1,9 @@
+package dev.woori.wooriLearn.domain.account.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BankTokenReqDto(
+        String userId
+) {
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/account/dto/BankTokenResDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/dto/BankTokenResDto.java
@@ -1,0 +1,8 @@
+package dev.woori.wooriLearn.domain.account.dto;
+
+public record BankTokenResDto(
+        String code,
+        String message,
+        TokenData data
+) {
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/account/dto/TokenData.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/dto/TokenData.java
@@ -1,0 +1,6 @@
+package dev.woori.wooriLearn.domain.account.dto;
+
+public record TokenData(
+        String accessToken
+) {
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/account/service/AccountService.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/service/AccountService.java
@@ -1,6 +1,21 @@
 package dev.woori.wooriLearn.domain.account.service;
 
+import dev.woori.wooriLearn.domain.account.dto.AccountUrlResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
 public class AccountService {
+    private final BankClient bankClient;
+    @Value("${external.bank.account-url}")
+    private String bankAccountUrl;
 
+    public AccountUrlResDto getAccountUrl(String userId) {
+        return AccountUrlResDto.builder()
+                .accessToken(bankClient.requestBankToken(userId).accessToken())
+                .url(bankAccountUrl)
+                .build();
+    }
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/account/service/BankClient.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/service/BankClient.java
@@ -1,0 +1,61 @@
+package dev.woori.wooriLearn.domain.account.service;
+
+import dev.woori.wooriLearn.config.exception.CommonException;
+import dev.woori.wooriLearn.config.exception.ErrorCode;
+import dev.woori.wooriLearn.domain.account.dto.BankTokenReqDto;
+import dev.woori.wooriLearn.domain.account.dto.BankTokenResDto;
+import dev.woori.wooriLearn.domain.account.dto.TokenData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BankClient {
+    private final RestTemplate restTemplate;
+    @Value("${external.bank.base-url}")
+    private String bankUrl;
+    @Value("${spring.env.app-key}")
+    private String appKey;
+    @Value("${spring.env.secret-key}")
+    private String secretKey;
+
+    public TokenData requestBankToken(String userId) {
+        // url 지정
+        String url = bankUrl + "/auth/token";
+
+        // 헤더 지정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("appKey", appKey);
+        headers.add("secretKey", secretKey);
+
+        // body 지정
+        BankTokenReqDto payload = BankTokenReqDto.builder().userId(userId).build();
+
+        // header + body를 모아 HttpEntity로 지정
+        HttpEntity<BankTokenReqDto> entity = new HttpEntity<>(payload, headers);
+
+        try {
+            // post 방식으로 요청을 보내기 (url/엔티티/응답 dto)
+            ResponseEntity<BankTokenResDto> response = restTemplate
+                    .postForEntity(url, entity, BankTokenResDto.class);
+
+            BankTokenResDto body = response.getBody();
+            System.out.println(body);
+            if (!response.getStatusCode().is2xxSuccessful() || body == null) {
+                log.error("인증서버 응답 오류: status={}, body={}", response.getStatusCode(), body);
+                throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "인증서버 응답이 올바르지 않습니다.");
+            }
+            return body.data();
+        } catch (RestClientException e) {
+            log.error("인증서버 통신 오류: {}", e.getMessage());
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "인증서버와 통신할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/dev/woori/wooriLearn/domain/account/service/BankClient.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/service/BankClient.java
@@ -12,12 +12,16 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class BankClient {
     private final RestTemplate restTemplate;
+    private static final String APP_KEY_HEADER = "appKey";
+    private static final String SECRET_KEY_HEADER = "secretKey";
+
     @Value("${external.bank.base-url}")
     private String bankUrl;
     @Value("${spring.env.app-key}")
@@ -27,13 +31,13 @@ public class BankClient {
 
     public TokenData requestBankToken(String userId) {
         // url 지정
-        String url = bankUrl + "/auth/token";
+        String url = UriComponentsBuilder.fromHttpUrl(bankUrl).path("/auth/token").toUriString();
 
         // 헤더 지정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.add("appKey", appKey);
-        headers.add("secretKey", secretKey);
+        headers.add(APP_KEY_HEADER, appKey);
+        headers.add(SECRET_KEY_HEADER, secretKey);
 
         // body 지정
         BankTokenReqDto payload = BankTokenReqDto.builder().userId(userId).build();
@@ -47,7 +51,6 @@ public class BankClient {
                     .postForEntity(url, entity, BankTokenResDto.class);
 
             BankTokenResDto body = response.getBody();
-            System.out.println(body);
             if (!response.getStatusCode().is2xxSuccessful() || body == null) {
                 log.error("인증서버 응답 오류: status={}, body={}", response.getStatusCode(), body);
                 throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "인증서버 응답이 올바르지 않습니다.");


### PR DESCRIPTION
## ✅ 연관된 이슈
#82 

## 📝 작업 내용
- 입력한 jwt 토큰 내부의 id값을 읽어들이고, id값을 body로 해 token 요청을 보냄
- 은행 서버에서 access token 응답이 오면 token + url 응답
    - 이 과정에서 우리 서버 - 은행 서버 간의 연결 설정

## 🖼️ 스크린샷 (선택)
<img width="1060" height="706" alt="image" src="https://github.com/user-attachments/assets/84027107-53b8-4b88-ae82-14945bb51c69" />
