### PR TITLE
[refactor] 관리자화면 포인트 환전 내역 조회 및 포인트 차감 승인 기능 연동

### DIFF
--- a/src/main/java/dev/woori/wooriLearn/config/security/SecurityConfig.java
+++ b/src/main/java/dev/woori/wooriLearn/config/security/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -74,7 +75,7 @@ public class SecurityConfig {
                 .addFilterBefore((request, response, chain) -> {
                     // dev/test용 임시 인증 세팅
                     SecurityContextHolder.getContext().setAuthentication(
-                            new UsernamePasswordAuthenticationToken("testuser", null, List.of())
+                            new UsernamePasswordAuthenticationToken("admin1", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")))
                     );
                     chain.doFilter(request, response);
                 }, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/dev/woori/wooriLearn/domain/account/dto/response/PointsHistoryResponseDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/dto/response/PointsHistoryResponseDto.java
@@ -11,16 +11,22 @@ import java.time.LocalDateTime;
 public class PointsHistoryResponseDto {
 
     private Long id;
+    private String userId;
+    private String nickname;
     private PointsHistoryType type;
     private PointsStatus status;
     private int amount;
     private LocalDateTime createdAt;
+    private LocalDateTime processedAt;
 
     public PointsHistoryResponseDto(PointsHistory entity) {
         this.id = entity.getId();
+        this.userId = entity.getUser() != null ? entity.getUser().getUserId() : null;
+        this.nickname = entity.getUser() != null ? entity.getUser().getNickname() : null;
         this.type = entity.getType();
         this.status = entity.getStatus();
         this.amount = entity.getAmount();
         this.createdAt = entity.getCreatedAt();
+        this.processedAt = entity.getProcessedAt();
     }
 }

--- a/src/main/java/dev/woori/wooriLearn/domain/account/dto/response/PointsHistoryResponseDto.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/dto/response/PointsHistoryResponseDto.java
@@ -21,8 +21,8 @@ public class PointsHistoryResponseDto {
 
     public PointsHistoryResponseDto(PointsHistory entity) {
         this.id = entity.getId();
-        this.userId = entity.getUser() != null ? entity.getUser().getUserId() : null;
-        this.nickname = entity.getUser() != null ? entity.getUser().getNickname() : null;
+        this.userId = entity.getUser().getUserId();
+        this.nickname = entity.getUser().getNickname();
         this.type = entity.getType();
         this.status = entity.getStatus();
         this.amount = entity.getAmount();

--- a/src/main/java/dev/woori/wooriLearn/domain/account/entity/HistoryFilter.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/entity/HistoryFilter.java
@@ -3,6 +3,7 @@ package dev.woori.wooriLearn.domain.account.entity;
 public enum HistoryFilter {
     ALL,
     DEPOSIT,
+    WITHDRAW,
     WITHDRAW_APPLY,
     WITHDRAW_FAILED,
     WITHDRAW_SUCCESS

--- a/src/main/java/dev/woori/wooriLearn/domain/account/repository/PointsHistoryRepository.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/repository/PointsHistoryRepository.java
@@ -24,6 +24,7 @@ public interface PointsHistoryRepository extends JpaRepository<PointsHistory, Lo
     Optional<PointsHistory> findAndLockById(@Param("id") Long id);
 
     // 단순 타입 + 상태 조회 (프론트 사용자 내역용)
+    @EntityGraph(attributePaths = {"user"})
     Page<PointsHistory> findByTypeAndStatus(PointsHistoryType type, PointsStatus status, Pageable pageable);
 
     /**

--- a/src/main/java/dev/woori/wooriLearn/domain/account/service/PointsHistoryService.java
+++ b/src/main/java/dev/woori/wooriLearn/domain/account/service/PointsHistoryService.java
@@ -40,7 +40,9 @@ public class PointsHistoryService {
      */
     public Page<PointsHistory> getUnifiedHistory(String username, PointsUnifiedHistoryRequestDto request, boolean isAdmin) {
         // 1) 조회 대상 사용자 식별
-        Long userId = resolveUserId(username, request.userId(), isAdmin);
+        Long userId = (isAdmin && request.userId() == null)
+                ? null
+                : resolveUserId(username, request.userId(), isAdmin);
 
         // 2) 날짜 범위 해석
         DateRange range = resolveDateRange(request.startDate(), request.endDate(), request.period());
@@ -85,6 +87,7 @@ public class PointsHistoryService {
         if (filter == null || filter == HistoryFilter.ALL) return new TypeStatus(null, null);
         return switch (filter) {
             case DEPOSIT -> new TypeStatus(PointsHistoryType.DEPOSIT, null);
+            case WITHDRAW -> new TypeStatus(PointsHistoryType.WITHDRAW, null);
             case WITHDRAW_APPLY -> new TypeStatus(PointsHistoryType.WITHDRAW, PointsStatus.APPLY);
             case WITHDRAW_FAILED -> new TypeStatus(PointsHistoryType.WITHDRAW, PointsStatus.FAILED);
             case WITHDRAW_SUCCESS -> new TypeStatus(PointsHistoryType.WITHDRAW, PointsStatus.SUCCESS);


### PR DESCRIPTION
## ✅ 연관된 이슈
#92 

## 📝 작업 내용
db 에 있는 모든 사용자의 환전 내역들 조회 api 연동
포인트 환전 신청 내역의 승인 버튼 클릭 시 내역에 연관된 사용자 포인트 차감
테스트 시 SecurityConfig.java 의 devFilterChain 메서드의 new UsernamePasswordAuthenticationToken("testuser", null, List.of())
를 new UsernamePasswordAuthenticationToken("testadmin", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))) 으로 수정하고 db에 있는 mock 관리자 의 role를 ROLE_ADMIN으로 수정하시고 테스트하시면됩니다.
아니면 yml 설정 active : prod로 수정하시고 해도되고요.
## 🖼️ 스크린샷 (선택)
<img width="1860" height="538" alt="image" src="https://github.com/user-attachments/assets/6c3f57e7-1dfa-4e99-98cf-d8d03af66c9e" />
사진의 내역에선 승인 버튼을 누르고 포인트 차감이 진행된 것입니다.